### PR TITLE
Airflow AI SDK Ollama example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 airflow_settings.yaml
 __pycache__/
+.idea/
 astro
 .venv
 airflow-webserver.pid

--- a/dags/ollama_blog_idea_generation.py
+++ b/dags/ollama_blog_idea_generation.py
@@ -42,7 +42,7 @@ class BlogIdea(ai_sdk.BaseModel):
     Product Name: [Insert Product Name Here]
     """,
 )
-def generate_blog_idea(product: dict | None = None) -> BlogIdea:
+def generate_blog_idea(product: dict | None = None):
     if product is None:
         raise AirflowSkipException("No product provided")
 

--- a/dags/ollama_blog_idea_generation.py
+++ b/dags/ollama_blog_idea_generation.py
@@ -64,7 +64,7 @@ def display_blog_ideas(blog_ideas: list[BlogIdea]):
 def ollama_blog_idea_generation():
     products = get_products()
     blog_ideas = generate_blog_idea.expand(product=products)
-    display_blog_ideas(blog_ideas)  # Pass the mapped XCom directly to the display task
+    display_blog_ideas(blog_ideas)
 
 ollama_blog_idea_generation_dag = ollama_blog_idea_generation()
 if __name__ == "__main__":

--- a/dags/ollama_blog_idea_generation.py
+++ b/dags/ollama_blog_idea_generation.py
@@ -1,5 +1,8 @@
 """
-This example consumes a list of products and produces a collection of blog ideas
+This example consumes a list of products and produces a collection of blog ideas.
+
+To run this example, you need to have ollama running locally. See https://github.com/ollama/ollama/blob/main/README.md#quickstart
+for more information.
 """
 
 import pendulum
@@ -9,6 +12,14 @@ from pydantic_ai.models.openai import OpenAIModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 import airflow_ai_sdk as ai_sdk
+
+model = OpenAIModel(
+    model_name="llama3.2",
+    provider=OpenAIProvider(
+        # change this to your ollama host if it's different
+        base_url="http://host.docker.internal:11434/v1"
+    ),
+)
 
 
 @task
@@ -27,12 +38,7 @@ class BlogIdea(ai_sdk.BaseModel):
 
 
 @task.llm(
-    model=OpenAIModel(
-        model_name="llama3.1:8b",
-        provider=OpenAIProvider(
-            base_url="http://host.docker.internal:11434/v1"
-        ),
-    ),
+    model=model,
     result_type=BlogIdea,
     system_prompt="""
     You are an experienced content strategist tasked with generating an engaging and informative blog idea based on a given product name. Given the product name provided, produce a compelling idea for a blog post.

--- a/dags/ollama_blog_idea_generation.py
+++ b/dags/ollama_blog_idea_generation.py
@@ -1,0 +1,71 @@
+"""
+This example consumes a list of products and produces a collection of blog ideas
+"""
+
+import pendulum
+from airflow.decorators import dag, task
+from airflow.exceptions import AirflowSkipException
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+import airflow_ai_sdk as ai_sdk
+
+
+@task
+def get_products() -> list[dict]:
+    """Get the list of products."""
+    return [
+        {"name": "Apache Airflow"},
+        {"name": "Astronomer"},
+        {"name": "Astro CLI"},
+    ]
+
+
+class BlogIdea(ai_sdk.BaseModel):
+    name: str
+    idea: str
+
+
+@task.llm(
+    model=OpenAIModel(
+        model_name="llama3.1:8b",
+        provider=OpenAIProvider(
+            base_url="http://host.docker.internal:11434/v1"
+        ),
+    ),
+    result_type=BlogIdea,
+    system_prompt="""
+    You are an experienced content strategist tasked with generating an engaging and informative blog idea based on a given product name. Given the product name provided, produce a compelling idea for a blog post.
+
+    Return only the name and the idea.
+
+    Product Name: [Insert Product Name Here]
+    """,
+)
+def generate_blog_idea(product: dict | None = None) -> BlogIdea:
+    if product is None:
+        raise AirflowSkipException("No product provided")
+
+    return f"Product Name: {product['name']}"
+
+
+@task
+def display_blog_ideas(blog_ideas: list[BlogIdea]):
+    """Display the list of generated blog ideas."""
+    from pprint import pprint
+
+    ideas_list = [{"product": idea['name'], "idea": idea['idea']} for idea in blog_ideas]
+    pprint(ideas_list)
+
+    return ideas_list
+
+
+@dag(schedule=None, start_date=pendulum.datetime(2025, 3, 1, tz="UTC"), catchup=False)
+def ollama_blog_idea_generation():
+    products = get_products()
+    blog_ideas = generate_blog_idea.expand(product=products)
+    display_blog_ideas(blog_ideas)  # Pass the mapped XCom directly to the display task
+
+ollama_blog_idea_generation_dag = ollama_blog_idea_generation()
+if __name__ == "__main__":
+    ollama_blog_idea_generation_dag.test()


### PR DESCRIPTION
#### Summary
This PR adds a new Airflow DAG example named `ollama_blog_idea_generation`, designed to generate engaging blog post ideas for a list of predefined products. It demonstrates the LLM capabilities provided by `airflow_ai_sdk` to automate the idea generation process without requiring a third-party LLM provider.

#### Key Changes:

1. **New DAG File**: `dags/ollama_blog_idea_generation.py` was added, defining the new DAG:
   - **Tasks Defined:**
     - `get_products`: Provides a static list of products (`Apache Airflow`, `Astronomer`, and `Astro CLI`).
     - `generate_blog_idea`: Utilizes an LLM (`llama3.1:8b`) hosted locally via OpenAIProvider to produce blog post ideas based on the given products.
     - `display_blog_ideas`: Outputs the generated blog ideas in a readable format for easy review.

2. **Gitignore Update**:
   - Added `.idea/` to `.gitignore` to exclude IDE-specific configuration from version control.

#### Implementation Details:
- The DAG is set with no schedule and does not enable catchup, ensuring manual or trigger-based execution.
- Pydantic models (`BlogIdea`) ensure structured output from the LLM task.
- Airflow task mapping (`generate_blog_idea.expand`) is employed for parallel execution per product.

#### Testing:
- The DAG includes a test invocation block (`if __name__ == "__main__":`) enabling local testing without deploying to Airflow environment.

#### Notes:
- Ensure local LLM infrastructure (`llama3.1`) is running at `host.docker.internal:11434` to successfully execute DAG tasks.
